### PR TITLE
0.98.5+sm1

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -212,10 +212,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             endpoints = self.get_endpoints()
             self.close_secure_channel()
@@ -230,10 +226,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()  # spec says it should not be necessary to open channel
             servers = self.find_servers()
             self.close_secure_channel()
@@ -248,10 +240,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             servers = self.find_servers_on_network()
             self.close_secure_channel()
@@ -267,10 +255,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             self.create_session()
         except Exception:

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -76,15 +76,14 @@ class KeepAlive(Thread):
 
 
 class Client(object):
-
     """
     High level client to connect to an OPC-UA server.
 
     This class makes it easy to connect and browse address space.
-    It attemps to expose as much functionality as possible
-    but if you want more flexibility it is possible and adviced to
-    use UaClient object, available as self.uaclient
-    which offers the raw OPC-UA services interface.
+    It attempts to expose as much functionality as possible
+    but if you want more flexibility it is possible and advised to
+    use the UaClient object, available as self.uaclient, which offers
+    the raw OPC-UA services interface.
     """
 
     def __init__(self, url, timeout=4):
@@ -213,6 +212,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             endpoints = self.get_endpoints()
             self.close_secure_channel()
@@ -227,6 +230,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()  # spec says it should not be necessary to open channel
             servers = self.find_servers()
             self.close_secure_channel()
@@ -241,6 +248,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             servers = self.find_servers_on_network()
             self.close_secure_channel()
@@ -256,6 +267,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             self.create_session()
         except Exception:
@@ -288,7 +303,10 @@ class Client(object):
         Send OPC-UA hello to server
         """
         ack = self.uaclient.send_hello(self.server_url.geturl(), self.max_messagesize, self.max_chunkcount)
-        # FIXME check ack
+
+        # TODO: Handle ua.UaError
+        if isinstance(ack, ua.UaStatusCodeError):
+            raise ack
 
     def open_secure_channel(self, renew=False):
         """

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -109,7 +109,7 @@ class UASocketClient(object):
         elif isinstance(msg, ua.Acknowledge):
             self._call_callback(0, msg)
         elif isinstance(msg, ua.ErrorMessage):
-            self.logger.warning("Received an error: %s", msg)
+            self._call_callback(0, ua.UaStatusCodeError(msg.Error.value))
         else:
             raise ua.UaError("Unsupported message type: %s", msg)
 

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -109,6 +109,7 @@ class UASocketClient(object):
         elif isinstance(msg, ua.Acknowledge):
             self._call_callback(0, msg)
         elif isinstance(msg, ua.ErrorMessage):
+            self.logger.fatal("Received an error: %s", msg)
             self._call_callback(0, ua.UaStatusCodeError(msg.Error.value))
         else:
             raise ua.UaError("Unsupported message type: %s", msg)

--- a/opcua/common/connection.py
+++ b/opcua/common/connection.py
@@ -289,7 +289,6 @@ class SecureConnection(object):
             return msg
         elif header.MessageType == ua.MessageType.Error:
             msg = struct_from_binary(ua.ErrorMessage, body)
-            logger.warning("Received an error: %s", msg)
             return msg
         else:
             raise ua.UaError("Unsupported message type {0}".format(header.MessageType))

--- a/opcua/common/connection.py
+++ b/opcua/common/connection.py
@@ -289,6 +289,7 @@ class SecureConnection(object):
             return msg
         elif header.MessageType == ua.MessageType.Error:
             msg = struct_from_binary(ua.ErrorMessage, body)
+            logger.warning("Received an error: %s", msg)
             return msg
         else:
             raise ua.UaError("Unsupported message type {0}".format(header.MessageType))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info[0] < 3:
     install_requires.extend(["enum34", "trollius", "futures"])
 
 setup(name="opcua",
-      version="0.98.5",
+      version="0.98.5+sm1",
       description="Pure Python OPC-UA client and server library",
       author="Olivier Roulet-Dubonnet",
       author_email="olivier.roulet@gmail.com",


### PR DESCRIPTION
Errors being sent back from the OPC UA server when the client sends hello are passed back to the parent thread/process, so they can be caught and surfaced. Otherwise, these types of errors are logged in the child thread(s) and the parent thread throws a timeout error. 

Testing with FactoryTX and a local instance of Prosys OPC UA Simulation Server:
**opcua 0.95.1+sm2**
```
2018-11-30 23:55:09.699 [OpcUaReceiver1 SM_AA_Example_1:opcua] 71 ERROR - Unexpected error: 
Traceback (most recent call last):
  File "/opt/sightmachine/factorytx2/factorytx/supervisor.py", line 70, in _run_process
    target.callable(*target.args, **target.kwargs)
  File "/opt/sightmachine/factorytx2/factorytx/receivers/opcua/receiver.py", line 326, in run
    with opcua.Client(self.url, timeout=self.timeout) as client:
  File "/usr/local/lib/python3.6/site-packages/opcua/client/client.py", line 122, in __enter__
    self.connect()
  File "/usr/local/lib/python3.6/site-packages/opcua/client/client.py", line 254, in connect
    self.send_hello()
  File "/usr/local/lib/python3.6/site-packages/opcua/client/client.py", line 286, in send_hello
    ack = self.uaclient.send_hello(self.server_url.geturl(), self.max_messagesize, self.max_chunkcount)
  File "/usr/local/lib/python3.6/site-packages/opcua/client/ua_client.py", line 224, in send_hello
    return self._uasocket.send_hello(url, max_messagesize, max_chunkcount)
  File "/usr/local/lib/python3.6/site-packages/opcua/client/ua_client.py", line 157, in send_hello
    ack = future.result(self.timeout)
  File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 434, in result
    raise TimeoutError()
concurrent.futures._base.TimeoutError
2018-11-30 23:55:10.701 [OpcUaReceiver1] 71 INFO - Backing off 2.0 seconds before restarting ...
2018-11-30 23:55:11.720 [core] 71 WARNING - Received an error: MessageAbort(error:StatusCode(Good), reason:Bad_TcpEndpointUrlInvalid (code=0x80830000, description="The Server does not recognize the QueryString specified."))
2018-11-30 23:55:11.720 [core] 71 WARNING - Received an error: MessageAbort(error:StatusCode(Good), reason:Bad_TcpEndpointUrlInvalid (code=0x80830000, description="The Server does not recognize the QueryString specified."))
```

**opcua 0.98.5+sm1**
```
2018-12-01 00:05:18.725 [OpcUaReceiver1 SM_AA_Example_1:opcua] 254 ERROR - OPC UA server responded with error BadTcpEndpointUrlInvalid: The server does not recognize the QueryString specified.
2018-12-01 00:05:19.716 [OpcUaReceiver1] 254 INFO - Backing off 2.0 seconds before restarting ...
2018-12-01 00:05:20.732 [OpcUaReceiver1 SM_AA_Example_1:opcua] 254 ERROR - OPC UA server responded with error BadTcpEndpointUrlInvalid: The server does not recognize the QueryString specified.
2018-12-01 00:05:20.962 [OpcUaReceiver2 SM_AA_Example_2:opcua] 255 INFO - Received 1 records.
2018-12-01 00:05:21.721 [OpcUaReceiver1] 254 INFO - Backing off 4.0 seconds before restarting ...
```

I ran the unit tests included with the python-opcua library and see all the tests passing:
```
Ran 377 tests in 49.730s

OK (skipped=8)
```